### PR TITLE
fix: permissions and packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
     dest: "{{ netplan_config_file }}"
     owner: root
     group: root
-    mode: u=rw,g=r,o=r
+    mode: u=rw,go=
   tags:
     - netplan
 

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,6 +1,5 @@
 ---
 netplan_packages:
-  - nplan
   - netplan.io
   - udev
 


### PR DESCRIPTION
- `nplan` does not exist in recent Ubuntu installs, resulting in this role to fail
- `netplan apply` complains that the permissions of the created file are too wide, `0600` is recommended.